### PR TITLE
window style for the primary stage

### DIFF
--- a/src/demo/groovy/TwoStagesDemo.groovy
+++ b/src/demo/groovy/TwoStagesDemo.groovy
@@ -1,7 +1,7 @@
 import groovyx.javafx.GroovyFX;
 
 GroovyFX.start {
-    stage(x: 100, y: 100, onShown: { println "Stage 1" }, visible: true) {
+    stage(x: 100, y: 100, onShown: { println "Stage 1" }, visible: true, style: 'UTILITY') {
         scene(width: 100, height: 100, fill: GROOVYBLUE)
     }
     stage(primary: false, x: 100, y: 400, visible: true) {

--- a/src/main/groovy/groovyx/javafx/factory/StageFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/StageFactory.groovy
@@ -91,7 +91,7 @@ class StageFactory extends AbstractFXBeanFactory {
             window = value
         } else if (primary && builder.variables.primaryStage != null) {
             window = builder.variables.primaryStage;
-            window.style = style;
+            window.initStyle(style)
         } else {
             window = new Stage(style)
             if(primary)


### PR DESCRIPTION
Right now you cannot do a style on the primary stage, such as going undecorated or utility.  This is because of an API inconsistency in JavaFX.
