### PR TITLE
WebEngine is not supported by the ARM preview of Java 8

### DIFF
--- a/src/main/groovy/groovyx/javafx/GroovyFXEnhancer.groovy
+++ b/src/main/groovy/groovyx/javafx/GroovyFXEnhancer.groovy
@@ -542,16 +542,17 @@ class GroovyFXEnhancer {
         MenuItem.metaClass {
             onAction << { Closure closure -> delegate.setOnAction(closure as EventHandler)}
         }
-        WebEngine.metaClass {
-            confirmHandler << { Closure closure -> delegate.setConfirmHandler(closure as Callback)}
-            createPopupHandler << { Closure closure -> delegate.setCreatePopupHandler(closure as Callback)}
-            promptHandler << { Closure closure -> delegate.setPromptHandler(closure as Callback)}
+        if( System.properties[ 'javafx.platform' ] != 'eglfb' ) {
+            WebEngine.metaClass {
+                confirmHandler << { Closure closure -> delegate.setConfirmHandler(closure as Callback)}
+                createPopupHandler << { Closure closure -> delegate.setCreatePopupHandler(closure as Callback)}
+                promptHandler << { Closure closure -> delegate.setPromptHandler(closure as Callback)}
 
-            onAlert << { Closure closure -> delegate.setOnAlert(closure as EventHandler)}
-            onResized << { Closure closure -> delegate.setOnResized(closure as EventHandler)}
-            onStatusChanged << { Closure closure -> delegate.setOnStatusChanged(closure as EventHandler)}
-            onVisibilityChanged << { Closure closure -> delegate.setOnVisibilityChanged(closure as EventHandler)}
-
+                onAlert << { Closure closure -> delegate.setOnAlert(closure as EventHandler)}
+                onResized << { Closure closure -> delegate.setOnResized(closure as EventHandler)}
+                onStatusChanged << { Closure closure -> delegate.setOnStatusChanged(closure as EventHandler)}
+                onVisibilityChanged << { Closure closure -> delegate.setOnVisibilityChanged(closure as EventHandler)}
+            }
         }
     }
 }


### PR DESCRIPTION
Ithis patch just checks to see if you have defined `javafx.platform=eglfb` (for running on the raspberry pi for example)

If it is defined, then WebEngine is not enhanced.  Without this, you get:

```
Caught: java.lang.RuntimeException: Exception in Application start method
java.lang.RuntimeException: Exception in Application start method
	at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:376)
	at com.sun.javafx.application.LauncherImpl.access$000(LauncherImpl.java:47)
	at com.sun.javafx.application.LauncherImpl$1.run(LauncherImpl.java:115)
Caused by: java.lang.ExceptionInInitializerError
	at com.sun.javafx.tk.quantum.QuantumToolkit$WebViewFactory.<clinit>(QuantumToolkit.java:1607)
	at com.sun.javafx.tk.quantum.QuantumToolkit.createPGWebView(QuantumToolkit.java:1096)
	at javafx.scene.web.WebEngine.<clinit>(WebEngine.java:266)
	at groovyx.javafx.GroovyFXEnhancer.class$(GroovyFXEnhancer.groovy)
	at groovyx.javafx.GroovyFXEnhancer.$get$$class$javafx$scene$web$WebEngine(GroovyFXEnhancer.groovy)
	at groovyx.javafx.GroovyFXEnhancer.enhanceClasses(GroovyFXEnhancer.groovy:545)
	at groovyx.javafx.GroovyFXEnhancer$enhanceClasses.call(Unknown Source)
	at groovyx.javafx.SceneGraphBuilder.<clinit>(SceneGraphBuilder.groovy:82)
	at groovyx.javafx.GroovyFX.start(GroovyFX.java:34)
	at com.sun.javafx.application.LauncherImpl$5.run(LauncherImpl.java:319)
	at com.sun.javafx.application.PlatformImpl$5.run(PlatformImpl.java:207)
	at com.sun.javafx.application.PlatformImpl$4.run(PlatformImpl.java:173)
	at com.sun.glass.ui.lens.LensApplication$RunnableEvent.dispatch(Unknown Source)
	at com.sun.glass.ui.lens.LensApplication._runLoop(Unknown Source)
	at com.sun.glass.ui.lens.LensApplication.access$400(Unknown Source)
	at com.sun.glass.ui.lens.LensApplication$4.run(Unknown Source)
Caused by: java.util.MissingResourceException: Can't find bundle for base name com.sun.webkit.build, locale en_US
	at com.sun.webkit.Utilities.<clinit>(Utilities.java:29)
	... 16 more
```