### PR TITLE
Remove public modifier from groovy methods

### DIFF
--- a/src/main/groovy/groovyx/javafx/animation/GTimeline.groovy
+++ b/src/main/groovy/groovyx/javafx/animation/GTimeline.groovy
@@ -30,7 +30,7 @@ import javafx.util.Duration
 class FunctionWrapper {
     public Closure closure;
 
-    public Object invoke() {
+    Object invoke() {
         return closure.call();
     }
 }

--- a/src/main/groovy/groovyx/javafx/animation/TargetHolder.groovy
+++ b/src/main/groovy/groovyx/javafx/animation/TargetHolder.groovy
@@ -33,11 +33,11 @@ class TargetHolder {
     public Object endValue;
     public Interpolator interpolator = Interpolator.LINEAR;
 
-    public String toString() {
+    String toString() {
         "bean = ${bean}, property = ${propertyName}, endValue = ${endValue}, interpolator = ${interpolator}"
     }
 
-    public KeyValue getKeyValue() {
+    KeyValue getKeyValue() {
         if(property == null) {
             property = Util.getJavaBeanFXWritableProperty(bean, propertyName);
         }

--- a/src/main/groovy/groovyx/javafx/binding/BindingHolder.groovy
+++ b/src/main/groovy/groovyx/javafx/binding/BindingHolder.groovy
@@ -40,12 +40,12 @@ class BindingHolder {
     ObservableValue binding;
     // the bound value from any bindTo.
     ObservableValue boundValue;
-    
-    public BindingHolder(Object value) {
+
+    BindingHolder(Object value) {
         this(null, value);
     }
-    
-    public BindingHolder(BindingHolder parent, Object value) {
+
+    BindingHolder(BindingHolder parent, Object value) {
         this.parent = parent;
         if(value instanceof ObservableValue) {
             observable  = value;
@@ -65,8 +65,8 @@ class BindingHolder {
         }
         
     }
-    
-    public BindingHolder bind() {
+
+    BindingHolder bind() {
         unbind();
         if(bindTo) {
            boundValue = bindTo.binding;
@@ -77,16 +77,16 @@ class BindingHolder {
        }
        this
     }
-    
-    public BindingHolder rebind() {
+
+    BindingHolder rebind() {
         if(boundValue) {
             unbind();
             bind();
         }
         this
     }
-    
-    public BindingHolder unbind() {
+
+    BindingHolder unbind() {
         if(boundValue) {
             if(boundValue instanceof Property) {
                 binding.unbindBidirectional(boundValue);
@@ -97,7 +97,8 @@ class BindingHolder {
         }
         this
     }
-    public ObservableValue getBinding() {
+
+    ObservableValue getBinding() {
        if(binding == null) {
            bind();
            binding = converter == null ? observable :
@@ -105,12 +106,12 @@ class BindingHolder {
        }
        binding 
     }
-    
-    public boolean isResolved() {
+
+    boolean isResolved() {
         return observable != null;
     }
-    
-    public ObservableValue resolve(Object instance) {
+
+    ObservableValue resolve(Object instance) {
         observable = Util.getJavaFXProperty(instance, propertyName);
         if(observable == null) 
             observable = Util.getJavaBeanFXProperty(instance, propertyName);
@@ -119,8 +120,8 @@ class BindingHolder {
         }
         return observable;
     }
-    
-    public BindingHolder using(Closure converter) {
+
+    BindingHolder using(Closure converter) {
         BindingHolder bh = lastHolder();
         bh.converter = converter
         bh.binding = null;
@@ -129,14 +130,15 @@ class BindingHolder {
             bh.parent.rebind();
         this
     }
-    
-    public BindingHolder to(Object value) {
+
+    BindingHolder to(Object value) {
         BindingHolder bh = lastHolder();
         bh.bindTo = new BindingHolder(bh, value);
         bh.bind();
         this
     }
-    public BindingHolder to(Object instance, String prop) {
+
+    BindingHolder to(Object instance, String prop) {
         BindingHolder bh = lastHolder();
         bh.bindTo = new BindingHolder(bh, [instance,prop]);
         bh.bind();

--- a/src/main/groovy/groovyx/javafx/canvas/AppendSVGPathOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/AppendSVGPathOperation.groovy
@@ -27,12 +27,12 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class AppendSVGPathOperation implements CanvasOperation {
     String svgpath
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         svgpath = val.toString();
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.appendSVGPath(svgpath);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ApplyEffectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ApplyEffectOperation.groovy
@@ -28,12 +28,12 @@ import javafx.scene.effect.Effect
 @FXBindable
 class ApplyEffectOperation implements CanvasOperation {
     Effect effect
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         effect = val;
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.applyEffect(effect);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ArcOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ArcOperation.groovy
@@ -32,8 +32,8 @@ class ArcOperation implements CanvasOperation {
     double radiusY;
     double startAngle;
     double length;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         centerX    = val[0];
         centerY    = val[1];
         radiusX    = val[2];
@@ -42,7 +42,7 @@ class ArcOperation implements CanvasOperation {
         length     = val[5];
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.arc(centerX, centerY, radiusX, radiusY, startAngle, length);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ArcToOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ArcToOperation.groovy
@@ -31,8 +31,8 @@ class ArcToOperation implements CanvasOperation {
     double x2;
     double y2;
     double radius
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x1     = val[0]
         y1     = val[1]
         x2     = val[2]
@@ -40,7 +40,7 @@ class ArcToOperation implements CanvasOperation {
         radius = val[4]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.arcTo(x1, y1, x2, y2, radius);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/BeginPathOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/BeginPathOperation.groovy
@@ -27,11 +27,11 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class BeginPathOperation implements CanvasOperation {
     
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.beginPath();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/BezierCurveToOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/BezierCurveToOperation.groovy
@@ -32,8 +32,8 @@ class BezierCurveToOperation implements CanvasOperation {
     double yc2; 
     double x1;
     double y1;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         xc1 = val[0] 
         yc1 = val[1]  
         xc2 = val[2]  
@@ -41,7 +41,7 @@ class BezierCurveToOperation implements CanvasOperation {
         x1  = val[4] 
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.bezierCurveTo(xc1, yc1, xc2, yc2, x1, y1);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/CanvasOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/CanvasOperation.groovy
@@ -23,9 +23,10 @@ import javafx.scene.canvas.GraphicsContext
  *
  * @author jimclarke
  */
-public interface CanvasOperation {
+interface CanvasOperation {
 
-    public void initParams(Object obj);
-    public void execute(GraphicsContext gc);
+    void initParams(Object obj);
+
+    void execute(GraphicsContext gc);
 }
 

--- a/src/main/groovy/groovyx/javafx/canvas/ClearRectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ClearRectOperation.groovy
@@ -30,15 +30,15 @@ class ClearRectOperation implements CanvasOperation {
     double y;
     double w;
     double h;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
         w = val[2]
         h = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.clearRect(x, y, w, h);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ClipOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ClipOperation.groovy
@@ -27,11 +27,11 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class ClipOperation implements CanvasOperation {
     
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.clip();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ClosePathOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ClosePathOperation.groovy
@@ -27,11 +27,11 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class ClosePathOperation implements CanvasOperation {
     
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.closePath();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ClosureOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ClosureOperation.groovy
@@ -27,12 +27,12 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class ClosureOperation implements CanvasOperation {
     Closure closure
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         closure = val
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         closure(gc)
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/DrawImageOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/DrawImageOperation.groovy
@@ -30,14 +30,14 @@ class DrawImageOperation implements CanvasOperation {
     Image img;
     double x;
     double y;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         img = val[0]
         x   = val[1]
         y   = val[2]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.drawImage(img, x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/DrawOperations.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/DrawOperations.groovy
@@ -35,33 +35,34 @@ import javafx.collections.FXCollections
 class DrawOperations implements CanvasOperation {
     private List<CanvasOperation> operations = [];
     Canvas canvas
-    
-    public void setOperations(List ops)
+
+    void setOperations(List ops)
     {
         this.operations = FXCollections.observableArrayList(ops)
     }
 
-    public void add(CanvasOperation opertion) {
+    void add(CanvasOperation opertion) {
         operations << operation;
     }
-    
-    public void clear() {
+
+    void clear() {
         operations.clear()
     }
-    
-    public void remove(CanvasOperation operation) {
+
+    void remove(CanvasOperation operation) {
         operations.remove(operation)
     }
-    
-    public void draw() {
+
+    void draw() {
         execute(canvas.graphicsContext2D)
     }
-    public void draw(Canvas canvas) {
+
+    void draw(Canvas canvas) {
         this.canvas = canvas;
         draw();
     }
-    
-    public void initParams(Object obj){
+
+    void initParams(Object obj){
         if(obj instanceof Canvas) {
             canvas = obj;
         }else {
@@ -73,7 +74,8 @@ class DrawOperations implements CanvasOperation {
             }
         }
     }
-    public void execute(GraphicsContext gc) {
+
+    void execute(GraphicsContext gc) {
         
         operations?.each {
             it.execute(gc);

--- a/src/main/groovy/groovyx/javafx/canvas/FillArcOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillArcOperation.groovy
@@ -34,8 +34,8 @@ class FillArcOperation implements CanvasOperation {
     double startAngle;
     double arcExtent;
     ArcType closure;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x          = val[0]
         y          = val[1]
         w          = val[2]
@@ -50,7 +50,7 @@ class FillArcOperation implements CanvasOperation {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fillArc(x, y, w, h, startAngle, arcExtent, closure);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/FillOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillOperation.groovy
@@ -26,11 +26,11 @@ import javafx.scene.canvas.GraphicsContext;
  */
 @FXBindable
 class FillOperation implements CanvasOperation {
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fill();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/FillOvalOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillOvalOperation.groovy
@@ -30,15 +30,15 @@ class FillOvalOperation implements CanvasOperation {
     double y;
     double w;
     double h;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
         w = val[2]
         h = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fillOval(x, y, w, h);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/FillPolygonOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillPolygonOperation.groovy
@@ -29,7 +29,8 @@ class FillPolygonOperation implements CanvasOperation {
     double[] xPoints;
     double[] yPoints;
     int nPoints
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val[0] instanceof Number) {
             xPoints = new double[1];
             xPoints[0] = val[0]
@@ -49,7 +50,7 @@ class FillPolygonOperation implements CanvasOperation {
         nPoints = val[3];
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fillPolygon(xPoints, yPoints, nPoints);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/FillRectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillRectOperation.groovy
@@ -30,15 +30,15 @@ class FillRectOperation implements CanvasOperation {
     double y;
     double w;
     double h;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
         w = val[2]
         h = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fillRect(x, y, w, h);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/FillRoundRectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillRoundRectOperation.groovy
@@ -32,8 +32,8 @@ class FillRoundRectOperation implements CanvasOperation {
     double h;
     double arcWidth;
     double arcHeight;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x         = val[0]
         y         = val[1]
         w         = val[2]
@@ -42,7 +42,7 @@ class FillRoundRectOperation implements CanvasOperation {
         arcHeight = val[5]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fillRoundRect(x, y, w, h, arcWidth, arcHeight);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/FillTextOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/FillTextOperation.groovy
@@ -29,14 +29,14 @@ class FillTextOperation implements CanvasOperation {
     String text;
     double x;
     double y;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         text = val[0].toString();
         x = val[1]
         y = val[2]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.fillText(text, x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/LineToOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/LineToOperation.groovy
@@ -28,13 +28,13 @@ import javafx.scene.canvas.GraphicsContext;
 class LineToOperation implements CanvasOperation {
     double x
     double y
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.lineTo(x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/MoveToOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/MoveToOperation.groovy
@@ -28,13 +28,13 @@ import javafx.scene.canvas.GraphicsContext;
 class MoveToOperation implements CanvasOperation {
     double x
     double y
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.moveTo(x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/QuadraticCurveToOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/QuadraticCurveToOperation.groovy
@@ -30,15 +30,15 @@ class QuadraticCurveToOperation implements CanvasOperation {
     double yc
     double x1 
     double y1
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         xc = val[0]
         yc = val[1]
         x1 = val[2]
         y1 = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.quadraticCurveTo(xc, yc, x1, y1);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/RectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/RectOperation.groovy
@@ -30,15 +30,15 @@ class RectOperation implements CanvasOperation {
     double y
     double w
     double h
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x         = val[0]
         y         = val[1]
         w         = val[2]
         h         = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.rect(x, y, w, h);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/RestoreOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/RestoreOperation.groovy
@@ -27,11 +27,11 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class RestoreOperation implements CanvasOperation {
     
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.restore();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/RotateOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/RotateOperation.groovy
@@ -27,12 +27,12 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class RotateOperation implements CanvasOperation {
     double degrees
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         degrees = val
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.rotate(degrees);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SaveOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SaveOperation.groovy
@@ -27,11 +27,11 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class SaveOperation implements CanvasOperation {
     
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.save();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/ScaleOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/ScaleOperation.groovy
@@ -28,13 +28,13 @@ import javafx.scene.canvas.GraphicsContext;
 class ScaleOperation implements CanvasOperation {
     double x
     double y
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.scale(x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetEffectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetEffectOperation.groovy
@@ -28,12 +28,12 @@ import javafx.scene.effect.Effect
 @FXBindable
 class SetEffectOperation implements CanvasOperation {
     Effect effect
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         effect = val;
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setEffect(effect);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetFillOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetFillOperation.groovy
@@ -29,12 +29,12 @@ import javafx.scene.paint.Paint
 @FXBindable
 class SetFillOperation implements CanvasOperation {
     Paint p;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         p = ColorFactory.get(val);
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setFill(p);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetFillRuleOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetFillRuleOperation.groovy
@@ -28,8 +28,8 @@ import javafx.scene.shape.FillRule
 @FXBindable
 class SetFillRuleOperation implements CanvasOperation {
     FillRule fillRule
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof FillRule) {
             fillRule = val;
         }else {
@@ -38,7 +38,7 @@ class SetFillRuleOperation implements CanvasOperation {
             
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setFillRule(fillRule);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetFontOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetFontOperation.groovy
@@ -29,12 +29,12 @@ import javafx.scene.text.Font
 @FXBindable
 class SetFontOperation implements CanvasOperation {
     Font f
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         f = FontFactory.get(val);
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setFont(f);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetGlobalAlphaOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetGlobalAlphaOperation.groovy
@@ -27,12 +27,12 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class SetGlobalAlphaOperation implements CanvasOperation {
     double alpha
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         alpha = val
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setGlobalAlpha(alpha);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetGlobalBlendModeOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetGlobalBlendModeOperation.groovy
@@ -28,8 +28,8 @@ import javafx.scene.effect.BlendMode
 @FXBindable
 class SetGlobalBlendModeOperation implements CanvasOperation {
     BlendMode mode
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof BlendMode) {
             mode = val;
         }else {
@@ -37,7 +37,7 @@ class SetGlobalBlendModeOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setGlobalBlendMode(mode);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetLineCapOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetLineCapOperation.groovy
@@ -28,8 +28,8 @@ import javafx.scene.shape.StrokeLineCap
 @FXBindable
 class SetLineCapOperation implements CanvasOperation {
     StrokeLineCap cap
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof StrokeLineCap) {
             cap = val;
         }else {
@@ -37,7 +37,7 @@ class SetLineCapOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setLineCap(cap);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetLineJoinOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetLineJoinOperation.groovy
@@ -28,8 +28,8 @@ import javafx.scene.shape.StrokeLineJoin
 @FXBindable
 class SetLineJoinOperation implements CanvasOperation {
     StrokeLineJoin join
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof StrokeLineJoin) {
             join = val;
         }else {
@@ -37,7 +37,7 @@ class SetLineJoinOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setLineJoin(join);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetLineWidthOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetLineWidthOperation.groovy
@@ -26,13 +26,13 @@ import javafx.scene.canvas.GraphicsContext;
  */
 @FXBindable
 class SetLineWidthOperation implements CanvasOperation {
-    double lw 
-    
-    public void initParams(Object val) {
+    double lw
+
+    void initParams(Object val) {
         lw = val
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setLineWidth(lw);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetMiterLimitOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetMiterLimitOperation.groovy
@@ -27,12 +27,12 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class SetMiterLimitOperation implements CanvasOperation {
     double ml
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         ml = val
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setMiterLimit(ml);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetStrokeOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetStrokeOperation.groovy
@@ -29,12 +29,12 @@ import javafx.scene.paint.Paint
 @FXBindable
 class SetStrokeOperation implements CanvasOperation {
     Paint p;
-     
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         p = ColorFactory.get(val);
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setStroke(p);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetTextAlignOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetTextAlignOperation.groovy
@@ -28,8 +28,8 @@ import javafx.scene.text.TextAlignment
 @FXBindable
 class SetTextAlignOperation implements CanvasOperation {
     TextAlignment align
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof TextAlignment) {
             align = val;
         }else {
@@ -37,7 +37,7 @@ class SetTextAlignOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setTextAlign(align);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetTextBaselineOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetTextBaselineOperation.groovy
@@ -29,8 +29,8 @@ import javafx.scene.canvas.GraphicsContext
 @FXBindable
 class SetTextBaselineOperation implements CanvasOperation {
     VPos baseline
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof VPos) {
             baseline = val;
         }else if(val instanceof Pos) {
@@ -40,7 +40,7 @@ class SetTextBaselineOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.setTextBaseline(baseline);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/SetTransformOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/SetTransformOperation.groovy
@@ -34,8 +34,8 @@ class SetTransformOperation implements CanvasOperation {
     double myy
     double mxt
     double myt
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof Affine)
             xform = val
         else {
@@ -48,7 +48,7 @@ class SetTransformOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         if(xform != null)
             gc.setTransform(xform)
         else

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeArcOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeArcOperation.groovy
@@ -34,8 +34,8 @@ class StrokeArcOperation implements CanvasOperation {
     double startAngle;
     double arcExtent;
     ArcType closure
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x          = val[0]
         y          = val[1]
         w          = val[2]
@@ -49,7 +49,7 @@ class StrokeArcOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokeArc(x, y, w, h, startAngle, arcExtent, closure);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeLineOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeLineOperation.groovy
@@ -30,15 +30,15 @@ class StrokeLineOperation implements CanvasOperation {
     double y1
     double x2
     double y2
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x1 = val[0]
         y1 = val[1]
         x2 = val[2]
         y2 = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokeLine(x1, y1, x2, y2);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeOperation.groovy
@@ -27,11 +27,11 @@ import javafx.scene.canvas.GraphicsContext;
 @FXBindable
 class StrokeOperation implements CanvasOperation {
     
-    public void initParams(Object val) {
+    void initParams(Object val) {
         
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.stroke();
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeOvalOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeOvalOperation.groovy
@@ -30,15 +30,15 @@ class StrokeOvalOperation implements CanvasOperation {
     double y
     double w
     double h
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x         = val[0]
         y         = val[1]
         w         = val[2]
         h         = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokeOval(x, y, w, h);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokePolygonOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokePolygonOperation.groovy
@@ -29,8 +29,8 @@ class StrokePolygonOperation implements CanvasOperation {
     double[] xPoints
     double[] yPoints
     int nPoints
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val[0] instanceof Number) {
             xPoints = new double[1];
             xPoints[0] = val[0]
@@ -50,7 +50,7 @@ class StrokePolygonOperation implements CanvasOperation {
         nPoints = val[3];
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokePolygon(xPoints, yPoints, nPoints);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokePolylineOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokePolylineOperation.groovy
@@ -29,8 +29,8 @@ class StrokePolylineOperation implements CanvasOperation {
     double[] xPoints
     double[] yPoints
     int nPoints
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
        if(val[0] instanceof Number) {
             xPoints = new double[1];
             xPoints[0] = val[0]
@@ -50,7 +50,7 @@ class StrokePolylineOperation implements CanvasOperation {
         nPoints = val[3]; 
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokePolyline(xPoints, yPoints, nPoints);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeRectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeRectOperation.groovy
@@ -30,15 +30,15 @@ class StrokeRectOperation implements CanvasOperation {
     double y
     double w
     double h
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x         = val[0]
         y         = val[1]
         w         = val[2]
         h         = val[3]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokeRect(x, y, w, h);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeRoundRectOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeRoundRectOperation.groovy
@@ -32,8 +32,8 @@ class StrokeRoundRectOperation implements CanvasOperation {
     double h;
     double arcWidth;
     double arcHeight;
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x         = val[0]
         y         = val[1]
         w         = val[2]
@@ -42,7 +42,7 @@ class StrokeRoundRectOperation implements CanvasOperation {
         arcHeight = val[5]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokeRoundRect(x, y, w, h, arcWidth, arcHeight);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/StrokeTextOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/StrokeTextOperation.groovy
@@ -29,14 +29,14 @@ class StrokeTextOperation implements CanvasOperation {
     String text
     double x
     double y
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         text = val[0].toString()
         x = val[1]
         y = val[2]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.strokeText(text, x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/canvas/TransformOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/TransformOperation.groovy
@@ -34,8 +34,8 @@ class TransformOperation implements CanvasOperation {
     double mxt
     double myt
     Affine xform
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         if(val instanceof Affine) {
             xform = val
         }else {
@@ -48,7 +48,7 @@ class TransformOperation implements CanvasOperation {
         }
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         if(xform != null)
             gc.transform(xform)
         else

--- a/src/main/groovy/groovyx/javafx/canvas/TranslateOperation.groovy
+++ b/src/main/groovy/groovyx/javafx/canvas/TranslateOperation.groovy
@@ -28,13 +28,13 @@ import javafx.scene.canvas.GraphicsContext;
 class TranslateOperation implements CanvasOperation {
     double x
     double y
-    
-    public void initParams(Object val) {
+
+    void initParams(Object val) {
         x = val[0]
         y = val[1]
     }
 
-    public void execute(GraphicsContext gc) {
+    void execute(GraphicsContext gc) {
         gc.translate(x, y);
     }
 }

--- a/src/main/groovy/groovyx/javafx/event/AbstractClosureProperty.groovy
+++ b/src/main/groovy/groovyx/javafx/event/AbstractClosureProperty.groovy
@@ -24,19 +24,20 @@ package groovyx.javafx.event
 class AbstractClosureProperty {
     String property
     Closure closure
-    
-    public AbstractClosureProperty() {
+
+    AbstractClosureProperty() {
     }
 
-    public AbstractClosureProperty(String property) {
+    AbstractClosureProperty(String property) {
         this.property = property
     }
-    public AbstractClosureProperty(String property, Closure closure) {
+
+    AbstractClosureProperty(String property, Closure closure) {
         this.property = property
         this.closure = closure
     }
-    
-    public String toString() {
+
+    String toString() {
         "${this.class.name}: property = ${property}"
     }
 }

--- a/src/main/groovy/groovyx/javafx/event/GroovyCallback.groovy
+++ b/src/main/groovy/groovyx/javafx/event/GroovyCallback.groovy
@@ -26,19 +26,20 @@ import javafx.util.Callback
 class GroovyCallback implements Callback {
     String property
     Closure closure
-    
-    public GroovyCallback() {
+
+    GroovyCallback() {
     }
 
-    public GroovyCallback(String property) {
+    GroovyCallback(String property) {
         this.property = property
     }
 
-    @Override public Object call(Object config) {
+    @Override
+    Object call(Object config) {
         return closure.call(config)
     }
 
-    public String toString() {
+    String toString() {
         "GroovyCallback: property = ${property}"
     }   
 }

--- a/src/main/groovy/groovyx/javafx/event/GroovyChangeListener.groovy
+++ b/src/main/groovy/groovyx/javafx/event/GroovyChangeListener.groovy
@@ -26,21 +26,24 @@ import javafx.beans.value.ObservableValue
 */
 class GroovyChangeListener extends AbstractClosureProperty implements ChangeListener {
     ObservableValue observable;
-    
-    public GroovyChangeListener() {
+
+    GroovyChangeListener() {
         super();
     }
-    
-    public GroovyChangeListener(String property) {
+
+    GroovyChangeListener(String property) {
         super(property);
     }
-    public GroovyChangeListener(String property, Closure closure) {
+
+    GroovyChangeListener(String property, Closure closure) {
         super(property, closure);
     }
-    public GroovyChangeListener(ObservableValue observable) {
+
+    GroovyChangeListener(ObservableValue observable) {
         this.observable = observable
     }
-    public GroovyChangeListener(ObservableValue observable, Closure closure) {
+
+    GroovyChangeListener(ObservableValue observable, Closure closure) {
         super(null, closure);
         this.observable = observable
     }

--- a/src/main/groovy/groovyx/javafx/event/GroovyEventHandler.groovy
+++ b/src/main/groovy/groovyx/javafx/event/GroovyEventHandler.groovy
@@ -26,18 +26,19 @@ import javafx.event.EventHandler
  */
  class GroovyEventHandler<E extends Event> extends AbstractClosureProperty implements EventHandler<E> {
     
-    public GroovyEventHandler() {
+    GroovyEventHandler() {
         super()
     }
 
-    public GroovyEventHandler(String property) {
+     GroovyEventHandler(String property) {
         super(property)
     }
-    public GroovyEventHandler(String property, Closure closure) {
+
+     GroovyEventHandler(String property, Closure closure) {
         super(property, closure)
     }
 
-    public void handle(E event) {
+     void handle(E event) {
         closure.call(event)
     }
 

--- a/src/main/groovy/groovyx/javafx/event/GroovyInvalidationListener.groovy
+++ b/src/main/groovy/groovyx/javafx/event/GroovyInvalidationListener.groovy
@@ -27,27 +27,30 @@ import javafx.beans.Observable
 class GroovyInvalidationListener extends AbstractClosureProperty implements InvalidationListener {
     
     Observable observable;
-    
-    public GroovyInvalidationListener() {
+
+    GroovyInvalidationListener() {
         super();
     }
-    
-    public GroovyInvalidationListener(String property) {
+
+    GroovyInvalidationListener(String property) {
         super(property);
     }
-    public GroovyInvalidationListener(String property, Closure closure) {
+
+    GroovyInvalidationListener(String property, Closure closure) {
         super(property, closure);
     }
-    public GroovyInvalidationListener(Observable observable) {
+
+    GroovyInvalidationListener(Observable observable) {
         super(null);
         this.observable = observable
     }
-    public GroovyInvalidationListener(Observable observable, Closure closure) {
+
+    GroovyInvalidationListener(Observable observable, Closure closure) {
         super(null, closure);
         this.observable = observable
     }
-    
-    public void invalidated(Observable observable) {
+
+    void invalidated(Observable observable) {
         this.closure.call(observable);
     }
 	

--- a/src/main/groovy/groovyx/javafx/factory/AbstractFxBeanFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/AbstractFxBeanFactory.groovy
@@ -27,24 +27,24 @@ class AbstractFXBeanFactory extends AbstractFactory {
     
     Map<String, Factory> childFactories;
 
-    public AbstractFXBeanFactory(Class beanClass) {
+    AbstractFXBeanFactory(Class beanClass) {
         this(beanClass, false)
     }
 
-    public AbstractFXBeanFactory(Class beanClass, boolean leaf) {
+    AbstractFXBeanFactory(Class beanClass, boolean leaf) {
         this.beanClass = beanClass
         this.leaf = leaf
     }
 
     @Override
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         if (checkValue(name, value)) {
             return value
         }
         return beanClass.newInstance()
     }
 
-    public boolean checkValue(Object name, Object value) {
+    boolean checkValue(Object name, Object value) {
         return value != null && beanClass.isAssignableFrom(value.class)
     }
 
@@ -64,21 +64,20 @@ class AbstractFXBeanFactory extends AbstractFactory {
         super.onHandleNodeAttributes(builder, node, attributes);
         return true;
     }
-    
-    public boolean hasChildFactories() {
+
+    boolean hasChildFactories() {
         return childFactories != null;
     }
-    
-    
-    
-    public void registerFactory(String name, Factory factory) {
+
+
+    void registerFactory(String name, Factory factory) {
         if(childFactories == null)
             childFactories = [(name):factory]
         else
             childFactories.put(name, factory);
     }
-    
-    public Factory resolveFactory(Object name, Map attributes, Object value) {
+
+    Factory resolveFactory(Object name, Map attributes, Object value) {
         childFactories == null? null : childFactories[name];
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/AbstractGradientFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/AbstractGradientFactory.groovy
@@ -26,7 +26,7 @@ import javafx.scene.paint.Stop
  */
 abstract class AbstractGradientFactory extends AbstractFXBeanFactory {
     
-    public AbstractGradientFactory(Class beanClass) {
+    AbstractGradientFactory(Class beanClass) {
         super(beanClass);
     }
     /**

--- a/src/main/groovy/groovyx/javafx/factory/AbstractNodeFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/AbstractNodeFactory.groovy
@@ -37,7 +37,7 @@ import javafx.scene.transform.Transform
  *
  * @author jimclarke
  */
-public abstract class AbstractNodeFactory extends AbstractFXBeanFactory {
+abstract class AbstractNodeFactory extends AbstractFXBeanFactory {
     
     public static def nodeEvents = [
         'onContextMenuRequested',
@@ -65,18 +65,17 @@ public abstract class AbstractNodeFactory extends AbstractFXBeanFactory {
         'onScroll'
         
     ]
-    
-    public AbstractNodeFactory(Class beanClass) {
+
+    AbstractNodeFactory(Class beanClass) {
         super(beanClass)
     }
-    public AbstractNodeFactory(Class beanClass, boolean leaf) {
+
+    AbstractNodeFactory(Class beanClass, boolean leaf) {
         super(beanClass, leaf)
     }
-    
-    
 
 
-     public boolean onHandleNodeAttributes( FactoryBuilderSupport builder, Object node, Map attributes ) {
+    boolean onHandleNodeAttributes(FactoryBuilderSupport builder, Object node, Map attributes ) {
         for(v in nodeEvents) {
             if(attributes.containsKey(v)) {
                 def val = attributes.remove(v);
@@ -96,8 +95,8 @@ public abstract class AbstractNodeFactory extends AbstractFXBeanFactory {
         return super.onHandleNodeAttributes(builder, node, attributes);
     }
 
-    
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
         switch(child) {
             case GroovyEventHandler:
                 FXHelper.setPropertyOrMethod(parent, child.property, child)

--- a/src/main/groovy/groovyx/javafx/factory/BindFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/BindFactory.groovy
@@ -28,26 +28,26 @@ import javafx.beans.value.ObservableValue
 class BindFactory extends AbstractFXBeanFactory {
     
     private static final String BIND_TO_PROPERTY = "__bindToList"
-    
-    public BindFactory() {
+
+    BindFactory() {
         super(ObservableValue)
     }
-    
-    public BindFactory(Class<ObservableValue> beanClass) {
+
+    BindFactory(Class<ObservableValue> beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
             throws InstantiationException, IllegalAccessException {
           BindingHolder bh = new BindingHolder(value);
           bh;
     }
-    
-    public boolean isHandlesNodeChildren() {
+
+    boolean isHandlesNodeChildren() {
         return true;
     }
-    
-     public boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
+
+    boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
         node.observable = new GroovyClosureProperty(childContent);
         false
     }

--- a/src/main/groovy/groovyx/javafx/factory/BorderPanePosition.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/BorderPanePosition.groovy
@@ -31,11 +31,12 @@ class BorderPanePosition {
     public Pos align;
     public Insets margin;
     public List<Node> nodes = new ArrayList<Node>();
-        
-    public void addNode(Node node) {
+
+    void addNode(Node node) {
         nodes.add(node);
     }
-    public Node getNode() {
+
+    Node getNode() {
         switch(nodes.size()) {
             case 0:
                 return null;

--- a/src/main/groovy/groovyx/javafx/factory/BorderPanePositionFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/BorderPanePositionFactory.groovy
@@ -32,18 +32,18 @@ class BorderPanePositionFactory extends AbstractFXBeanFactory {
     BorderPanePositionFactory(Class<BorderPanePosition> beanClass) {
         super(beanClass)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
        BorderPanePosition bpp = super.newInstance(builder, name, value, attributes);
        bpp.property = name;
        bpp;
     }
-    
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
          if (child instanceof javafx.scene.Node) parent.addNode(child);
     }
-    
-    public void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object bpp) {
+
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object bpp) {
         InvokerHelper.setProperty(parent, bpp.property, bpp.node);
         if(bpp.align != null) {
             BorderPane.setAlignment(bpp.node, bpp.align);

--- a/src/main/groovy/groovyx/javafx/factory/CanvasClosureOperationFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/CanvasClosureOperationFactory.groovy
@@ -31,20 +31,20 @@ class CanvasClosureOperationFactory extends AbstractFXBeanFactory {
     CanvasClosureOperationFactory(Class<ClosureOperation> beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
             throws InstantiationException, IllegalAccessException {
          Object instance = super.newInstance(builder,name,value, attributes);
          if(value != null && value instanceof Closure)
             instance.closure = value;
          instance;
     }
-    
-    public boolean isHandlesNodeChildren() {
+
+    boolean isHandlesNodeChildren() {
         return true;
     }
 
-    public boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
+    boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
         node.closure = childContent
         return false
     }

--- a/src/main/groovy/groovyx/javafx/factory/CanvasFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/CanvasFactory.groovy
@@ -43,7 +43,7 @@ class CanvasFactory extends AbstractNodeFactory {
     }
     
     @Override
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if (child instanceof CanvasOperation) {
             def operations = builder.parentContext.get(CANVAS_OPERATIONS_LIST_PROPERTY, [])
             operations << child

--- a/src/main/groovy/groovyx/javafx/factory/CanvasOperationFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/CanvasOperationFactory.groovy
@@ -33,8 +33,8 @@ class CanvasOperationFactory extends AbstractFXBeanFactory {
     CanvasOperationFactory(Class<CanvasOperation> beanClass) {
         super(beanClass);
     }
-    
-     public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
             throws InstantiationException, IllegalAccessException {
          Object result = super.newInstance(builder, name, value, attributes);
          if(value != null) {

--- a/src/main/groovy/groovyx/javafx/factory/CellFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/CellFactory.groovy
@@ -25,24 +25,25 @@ import groovyx.javafx.event.GroovyCallback
 */
 class CellFactory extends AbstractNodeFactory {
     
-    public CellFactory() {
+    CellFactory() {
         super(GroovyCallback)
     }
-    public CellFactory(Class<GroovyCallback> beanClass) {
+
+    CellFactory(Class<GroovyCallback> beanClass) {
         super(beanClass)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Object factory = super.newInstance(builder, name, value, attributes);
         factory.property = name;
         factory;
     }
-    
-    public boolean isHandlesNodeChildren() {
+
+    boolean isHandlesNodeChildren() {
         return true;
     }
 
-    public boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
+    boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
         node.closure = childContent;
         return false;
     }

--- a/src/main/groovy/groovyx/javafx/factory/ChangeFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ChangeFactory.groovy
@@ -30,8 +30,8 @@ class ChangeFactory extends AbstractFXBeanFactory {
     ChangeFactory(Class beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
             throws InstantiationException, IllegalAccessException {
          def listener = null;
          if(ChangeListener.isAssignableFrom(beanClass)) {
@@ -63,12 +63,12 @@ class ChangeFactory extends AbstractFXBeanFactory {
          }   
          listener
     }
-    
-    public boolean isHandlesNodeChildren() {
+
+    boolean isHandlesNodeChildren() {
         return true;
     }
 
-    public boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
+    boolean onNodeChildren(FactoryBuilderSupport builder, Object node, Closure childContent) {
         node.closure = childContent
         if(node.observable != null) {
             node.observable.addListener(node);

--- a/src/main/groovy/groovyx/javafx/factory/ClipFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ClipFactory.groovy
@@ -23,7 +23,7 @@ import javafx.scene.Node;
  *
  * @author jimclarke
  */
-public class ClipFactory extends AbstractFXBeanFactory {
+class ClipFactory extends AbstractFXBeanFactory {
     
     ClipFactory() {
         super(ClipHolder);
@@ -32,15 +32,15 @@ public class ClipFactory extends AbstractFXBeanFactory {
     ClipFactory(Class<ClipHolder> beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) {
         ClipHolder ch = super.newInstance(builder, name, value, attributes);
         if(value instanceof Node)
             ch.node = value;
         return ch;
     }
-    
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
         if(child instanceof Node) {
             ch.node = child;
         }

--- a/src/main/groovy/groovyx/javafx/factory/ClosureHandlerFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ClosureHandlerFactory.groovy
@@ -26,11 +26,11 @@ import groovyx.javafx.event.GroovyEventHandler
 class ClosureHandlerFactory extends AbstractFXBeanFactory {
     
     
-    public ClosureHandlerFactory(Class beanClass) {
+    ClosureHandlerFactory(Class beanClass) {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         GroovyEventHandler eh = super.newInstance(builder, name, value, attributes);
         eh.property = name.toString();
         if(value instanceof Closure) {

--- a/src/main/groovy/groovyx/javafx/factory/ColorFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ColorFactory.groovy
@@ -37,11 +37,11 @@ import java.util.regex.Pattern
  * @author jimclarke
  * minor adaptions by hackergarten
  */
-public class ColorFactory {
+class ColorFactory {
 
     private static Map <String, Paint> colorCacheMap = new HashMap<String, Paint>();
 
-    public static Paint get(Object value) {
+    static Paint get(Object value) {
         if(value instanceof Paint) {
             return (Paint)value;
         } /*else if(value instanceof RadialGradientBuilder || value instanceof LinearGradientBuilder) {

--- a/src/main/groovy/groovyx/javafx/factory/ContainerFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ContainerFactory.groovy
@@ -34,7 +34,7 @@ class ContainerFactory extends AbstractNodeFactory {
     }
 
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if (child instanceof Node) {
             if (parent instanceof BorderPane) {
                 parent.setCenter(child)

--- a/src/main/groovy/groovyx/javafx/factory/ControlFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ControlFactory.groovy
@@ -49,11 +49,11 @@ import javafx.scene.control.TreeView
  */
 class ControlFactory extends AbstractNodeFactory {
 
-    public ControlFactory(Class beanClass) {
+    ControlFactory(Class beanClass) {
         super(beanClass);
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Control control = super.newInstance(builder, name, value, attributes);
         if(value != null) {
               control.text = value.toString();
@@ -74,7 +74,7 @@ class ControlFactory extends AbstractNodeFactory {
         }
     }
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         switch(child) {
             case Tooltip:
                 parent.setTooltip(child);
@@ -88,7 +88,7 @@ class ControlFactory extends AbstractNodeFactory {
                         case TabPane:
                         case TreeView:
                             parent.selectionModel.selectedItemProperty().addListener(new ChangeListener() {
-                                public void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
+                                void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
                                     builder.defer({child.closure.call(parent, newValue);});
                                 }
                             }); 
@@ -186,7 +186,7 @@ class ControlFactory extends AbstractNodeFactory {
         }
     }
 
-    public void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object child) {
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object child) {
         if (child instanceof SplitPane) {
             def cntx = builder.getContext();
             List dividers = cntx.get(SceneGraphBuilder.CONTEXT_DIVIDER_KEY);

--- a/src/main/groovy/groovyx/javafx/factory/CustomNodeFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/CustomNodeFactory.groovy
@@ -27,25 +27,25 @@ import javafx.scene.Parent
 class CustomNodeFactory extends AbstractNodeFactory {
 
 
-    public CustomNodeFactory(Class beanClass) {
+    CustomNodeFactory(Class beanClass) {
         super(beanClass)
     }
-    
-    public CustomNodeFactory(Class beanClass, boolean leaf) {
+
+    CustomNodeFactory(Class beanClass, boolean leaf) {
         super(beanClass, leaf)
     }
-    
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         if ((value != null) && checkValue(name, value)) {
             return value;
         } else {
             throw new RuntimeException("$name must have either a value argument that must be of type $beanClass.name");
         }
     }
-    
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if (parent instanceof Parent && child instanceof Node)  {
             parent.children.add(child);
         }else {

--- a/src/main/groovy/groovyx/javafx/factory/DrawFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/DrawFactory.groovy
@@ -43,7 +43,7 @@ class DrawFactory extends AbstractNodeFactory {
     }
     
     @Override
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         DrawOperations operations = super.newInstance(builder, name, value, attributes);
         if(value instanceof Canvas)
             operations.canvas = value;
@@ -51,7 +51,7 @@ class DrawFactory extends AbstractNodeFactory {
     }
     
     @Override
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if (child instanceof CanvasOperation) {
             def operations = builder.parentContext.get(DRAW_OPERATIONS_LIST_PROPERTY, [])
             operations << child

--- a/src/main/groovy/groovyx/javafx/factory/EffectFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/EffectFactory.groovy
@@ -34,7 +34,7 @@ class EffectFactory extends AbstractFXBeanFactory {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
             throws InstantiationException, IllegalAccessException {
         def effect = super.newInstance(builder, name, value, attributes);
         if(EffectWrapper.isAssignableFrom(beanClass)) {
@@ -44,7 +44,7 @@ class EffectFactory extends AbstractFXBeanFactory {
     }
 
     @SuppressWarnings('EmptyIfStatement')
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if (child instanceof Effect) {
             if(parent.metaClass.hasProperty(parent, "input")) {
                FXHelper.setPropertyOrMethod(parent, "input", child)

--- a/src/main/groovy/groovyx/javafx/factory/FXMLFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/FXMLFactory.groovy
@@ -36,8 +36,8 @@ class FXMLFactory extends AbstractNodeFactory {
     FXMLFactory(Class<Node> beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Node result
         if(value != null) {
             result = processValue(value);
@@ -115,7 +115,7 @@ class FXMLFactory extends AbstractNodeFactory {
     }
     
     @Override
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         Node childNode = processValue(child);
         if(childNode != null) {
             parent.children.add(childNode);

--- a/src/main/groovy/groovyx/javafx/factory/FXMLLoaderBuilder.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/FXMLLoaderBuilder.groovy
@@ -25,8 +25,8 @@ import javafx.fxml.FXMLLoader;
  */
 class FXMLLoaderBuilder {
     public String xml;
-    
-    public Object build() {
+
+    Object build() {
         def loader = new FXMLLoader();
         def ins = new ByteArrayInputStream(xml.getBytes());
         try {

--- a/src/main/groovy/groovyx/javafx/factory/FilterFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/FilterFactory.groovy
@@ -28,8 +28,8 @@ class FilterFactory extends AbstractFXBeanFactory {
     FilterFactory() {
         super(null, true)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
        def extName = value;
        if(extName == null) {
            extName = attributes.remove("description");

--- a/src/main/groovy/groovyx/javafx/factory/FontFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/FontFactory.groovy
@@ -29,7 +29,7 @@ import javafx.scene.text.Font
  * minor adaptions by hackergarten
  */
 class FontFactory {
-    public static Font get(Object value) {
+    static Font get(Object value) {
         if(value instanceof Font) {
             return (Font)value;
         }else  {

--- a/src/main/groovy/groovyx/javafx/factory/GraphicFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/GraphicFactory.groovy
@@ -32,19 +32,19 @@ class GraphicFactory extends AbstractFXBeanFactory {
     GraphicFactory(Class<Graphic> beanClass) {
         super(beanClass)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
        Graphic graphic = super.newInstance(builder, name, value, attributes)
        if(value instanceof Node)
                graphic.node = value;
         graphic;
     }
-    
-     public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
          parent.node = child;
      }
-    
-    public void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
+
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
         parent.graphic = node.node;
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/GridColumn.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/GridColumn.groovy
@@ -25,8 +25,8 @@ import javafx.scene.Node;
 class GridColumn {
     int index;
     List nodes = new ArrayList();
-    
-    public Node[] nodeArray() {
+
+    Node[] nodeArray() {
         return (Node[])nodes.toArray(new Node[nodes.size()]);
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/GridConstraint.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/GridConstraint.groovy
@@ -39,13 +39,13 @@ class GridConstraint {
    Priority hgrow = Priority.NEVER;
    Priority vgrow = Priority.NEVER;
    Insets margin = new Insets(0,0,0,0);
-   
-   public void updateConstraints() {
+
+    void updateConstraints() {
        GridPane.setConstraints(node, column, row, columnSpan, rowSpan,
         halignment, valignment, hgrow, vgrow, margin);
    }
-   
-    public void clearConstraints() {
+
+    void clearConstraints() {
         GridPane.clearConstraings(node);
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/GridConstraintFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/GridConstraintFactory.groovy
@@ -31,7 +31,7 @@ class GridConstraintFactory extends AbstractFXBeanFactory {
         super(beanClass);
     }
     @Override
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
     throws InstantiationException, IllegalAccessException {
         def gc = super.newInstance(builder, name, value, attributes)
         FXHelper.fxAttributes(gc, attributes)
@@ -50,7 +50,7 @@ class GridConstraintFactory extends AbstractFXBeanFactory {
     }
 
     @Override
-    public void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
         if (node instanceof GridConstraint) {
             node.node = parent
             node.updateConstraints()

--- a/src/main/groovy/groovyx/javafx/factory/GridRow.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/GridRow.groovy
@@ -25,8 +25,8 @@ import javafx.scene.Node;
 class GridRow {
     int index;
     List nodes = new ArrayList();
-    
-    public Node[] nodeArray() {
+
+    Node[] nodeArray() {
         return (Node[])nodes.toArray(new Node[nodes.size()]);
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/GridRowColumnFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/GridRowColumnFactory.groovy
@@ -25,15 +25,15 @@ class GridRowColumnFactory extends AbstractFXBeanFactory {
     GridRowColumnFactory(Class beanClass) {
         super(beanClass)
     }
-    
-     public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
          if(child instanceof List)
             parent.nodes.addAll(child);
          else
             parent.nodes.add(child);
      }
-    
-    public void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
+
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
         switch(node) {
             case GridRow:
                 parent.addRow(node.index, node.nodeArray());

--- a/src/main/groovy/groovyx/javafx/factory/ImageFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ImageFactory.groovy
@@ -30,7 +30,8 @@ class ImageFactory extends AbstractFXBeanFactory {
     ImageFactory(Class<Image> beanClass) {
         super(beanClass);
     }
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         if (checkValue(name, value)) {
             return value
         }
@@ -61,7 +62,8 @@ class ImageFactory extends AbstractFXBeanFactory {
         }
         return image;
     }
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
         if(child instanceof Image && parent instanceof Image) {
             ((Image)parent).setPlaceHolder((Image)child);
         }

--- a/src/main/groovy/groovyx/javafx/factory/ImageViewFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ImageViewFactory.groovy
@@ -26,15 +26,15 @@ import javafx.scene.image.ImageView
 */
 class ImageViewFactory extends AbstractNodeFactory {
     
-    public ImageViewFactory() {
+    ImageViewFactory() {
         super(ImageView);
     }
-    
-    public ImageViewFactory(Class<ImageView> beanClass) {
+
+    ImageViewFactory(Class<ImageView> beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         ImageView iv = super.newInstance(builder, name, value, attributes);
         if(value != null) {
             switch(value) {
@@ -51,8 +51,8 @@ class ImageViewFactory extends AbstractNodeFactory {
         }
         iv
     }
-    
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
         switch(child) {
             case Image:
                 parent.image = child;

--- a/src/main/groovy/groovyx/javafx/factory/LabeledFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/LabeledFactory.groovy
@@ -41,7 +41,7 @@ class LabeledFactory extends AbstractNodeFactory {
         super(beanClass);
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Action action = null
         Map actionParams = [:]
         if (value instanceof Action) {
@@ -79,7 +79,7 @@ class LabeledFactory extends AbstractNodeFactory {
     }
 
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         switch (child) {
             case Tooltip:
                 parent.tooltip = child;
@@ -96,7 +96,7 @@ class LabeledFactory extends AbstractNodeFactory {
             case GroovyCallback:
                 if ((parent instanceof ChoiceBox) && (child.property == "onSelect")) {
                     parent.selectionModel.selectedItemProperty().addListener(new ChangeListener() {
-                        public void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
+                        void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
                             builder.defer({child.closure.call(parent, newValue);});
                         }
                     });

--- a/src/main/groovy/groovyx/javafx/factory/ListViewFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ListViewFactory.groovy
@@ -36,7 +36,7 @@ class ListViewFactory extends AbstractNodeFactory {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         ListView listView = super.newInstance(builder, name, value, attributes);
         def items = attributes.remove("items");
         if(items != null) {
@@ -47,7 +47,7 @@ class ListViewFactory extends AbstractNodeFactory {
         final def onSelect = attritues.remove("onSelect");
         if(onSelect != null) {
              listView.selectionModel.selectedItemProperty().addChangeListener(new ChangeListener() {
-                public void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
+                void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
                     builder.defer({onSelect.call(newValue);});
                 }
              });

--- a/src/main/groovy/groovyx/javafx/factory/MediaPlayerFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/MediaPlayerFactory.groovy
@@ -31,7 +31,8 @@ class MediaPlayerFactory extends AbstractFXBeanFactory{
     MediaPlayerFactory(Class<MediaPlayer> beanClass) {
         super(beanClass)
     }
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         if (checkValue(name, value)) {
             return value
         }

--- a/src/main/groovy/groovyx/javafx/factory/MenuFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/MenuFactory.groovy
@@ -39,7 +39,7 @@ class MenuFactory extends AbstractNodeFactory {
         super(beanClass);
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Action action = null
         Map actionParams = [:]
         if (value instanceof Action) {
@@ -66,7 +66,7 @@ class MenuFactory extends AbstractNodeFactory {
         menu
     }
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if(parent instanceof MenuBar && child instanceof Menu) {
             parent.menus.add(child);
         }else if (child instanceof MenuItem) {

--- a/src/main/groovy/groovyx/javafx/factory/MenuItemFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/MenuItemFactory.groovy
@@ -112,8 +112,8 @@ class MenuItemFactory extends AbstractNodeFactory {
         }
         menu
     }
-    
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if(parent instanceof Menu && child instanceof MenuItem) {
             parent.items.add(child);        
         } else if(child instanceof Node) {

--- a/src/main/groovy/groovyx/javafx/factory/NodeFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/NodeFactory.groovy
@@ -22,10 +22,11 @@ package groovyx.javafx.factory
 * @author jimclarke
 */
 class NodeFactory extends AbstractNodeFactory {
-    public NodeFactory(Class beanClass) {
+    NodeFactory(Class beanClass) {
         super(beanClass)
     }
-    public NodeFactory(Class beanClass, boolean leaf) {
+
+    NodeFactory(Class beanClass, boolean leaf) {
         super(beanClass, leaf)
     }
     

--- a/src/main/groovy/groovyx/javafx/factory/PathFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/PathFactory.groovy
@@ -30,7 +30,7 @@ class PathFactory extends ShapeFactory {
         super(shapeClass)
     }
 
-    public void setChild(FactoryBuilderSupport build, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport build, Object parent, Object child) {
         if(child instanceof PathElement)
             ((Path)parent).getElements().add((PathElement)child);
         else

--- a/src/main/groovy/groovyx/javafx/factory/ResourceFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/ResourceFactory.groovy
@@ -26,7 +26,7 @@ class ResourceFactory extends AbstractFXBeanFactory {
         super(null, true)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
         throws InstantiationException, IllegalAccessException {
         if(value instanceof List) {
              List result = [];

--- a/src/main/groovy/groovyx/javafx/factory/SceneFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/SceneFactory.groovy
@@ -45,7 +45,7 @@ class SceneFactory extends AbstractFXBeanFactory {
         super(beanClass);
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Scene scene;
         if (checkValue(name, value)) {
             scene = value
@@ -69,7 +69,7 @@ class SceneFactory extends AbstractFXBeanFactory {
         return scene;
     }
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         Scene scene = (Scene)parent
 
         // If we have a synthetic root, then the first child Node either becomes
@@ -108,7 +108,7 @@ class SceneFactory extends AbstractFXBeanFactory {
         }
     }
 
-    public boolean onHandleNodeAttributes( FactoryBuilderSupport builder, Object node, Map attributes ) {
+    boolean onHandleNodeAttributes(FactoryBuilderSupport builder, Object node, Map attributes ) {
         def scene = (Scene)node
         def attr = attributes.remove("stylesheets")
         if(attr) {

--- a/src/main/groovy/groovyx/javafx/factory/StageFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/StageFactory.groovy
@@ -30,11 +30,11 @@ import javafx.stage.StageStyle
  */
 class StageFactory extends AbstractFXBeanFactory {
     
-    public StageFactory(Class beanClass) {
+    StageFactory(Class beanClass) {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
             throws InstantiationException, IllegalAccessException {
                 if(Stage.isAssignableFrom(beanClass)) {
                     return handleStage(builder, name, value, attributes)
@@ -106,7 +106,7 @@ class StageFactory extends AbstractFXBeanFactory {
         window;
     }
 
-    public void setChild(FactoryBuilderSupport build, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport build, Object parent, Object child) {
         if(parent instanceof Popup) {
             parent.content.add(child);
         }else if(parent instanceof FileChooser && child instanceof FileChooser.ExtensionFilter) {
@@ -116,7 +116,7 @@ class StageFactory extends AbstractFXBeanFactory {
         }
     }
 
-    public void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node) {
         if(node instanceof Stage) {
             if(node.getWidth() == -1)
                 node.sizeToScene();

--- a/src/main/groovy/groovyx/javafx/factory/StrokeFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/StrokeFactory.groovy
@@ -27,10 +27,11 @@ import javafx.scene.paint.Paint
  */
 class StrokeFactory extends AbstractFXBeanFactory {
     
-    public StrokeFactory() {
+    StrokeFactory() {
         super(Paint, true)
     }
-    public StrokeFactory(Class<Paint> beanClass) {
+
+    StrokeFactory(Class<Paint> beanClass) {
         super(beanClass, true)
     }
     Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) {

--- a/src/main/groovy/groovyx/javafx/factory/StylesheetFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/StylesheetFactory.groovy
@@ -28,7 +28,8 @@ class StylesheetFactory extends AbstractFXBeanFactory {
     StylesheetFactory(Class<List> beanClass) {
         super(beanClass, true)
     }
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
         throws InstantiationException, IllegalAccessException {
         if (checkValue(name, value)) {
             return value

--- a/src/main/groovy/groovyx/javafx/factory/TabFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TabFactory.groovy
@@ -27,13 +27,15 @@ import javafx.scene.control.Tooltip
  */
 class TabFactory extends AbstractFXBeanFactory {
     
-    public TabFactory() {
+    TabFactory() {
         super(Tab);
     }
-    public TabFactory(Class<Tab> beanClass) {
+
+    TabFactory(Class<Tab> beanClass) {
         super(beanClass);
     }
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Tab tab = super.newInstance(builder, name, value, attributes);
         switch(value) {
             case GString:
@@ -46,7 +48,7 @@ class TabFactory extends AbstractFXBeanFactory {
         return tab
     }
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         switch(child) {
             case Tooltip:
                 parent.tooltip = child

--- a/src/main/groovy/groovyx/javafx/factory/TableCellFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TableCellFactory.groovy
@@ -26,12 +26,14 @@ import javafx.scene.control.TableCell;
 class TableCellFactory {
     Closure factory;
 
-    public TableCellFactory() {
+    TableCellFactory() {
     }
-    public TableCellFactory(Closure factory) {
+
+    TableCellFactory(Closure factory) {
         this.factory = factory;
     }
-    public TableCell run() {
+
+    TableCell run() {
         def result = factory.call();
 
         return result;

--- a/src/main/groovy/groovyx/javafx/factory/TableFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TableFactory.groovy
@@ -47,7 +47,7 @@ import java.lang.reflect.Method
  */
 
 class EditingCallback implements javafx.util.Callback {
-    public Object call(Object column) {
+    Object call(Object column) {
         return new EditingCell();
     }
 }
@@ -55,13 +55,13 @@ class EditingCallback implements javafx.util.Callback {
 class EditingCell extends TableCell implements EventHandler {
     private TextField textField;
 
-    public EditingCell() {
+    EditingCell() {
         this.setEditable(true);
     }
 
 
     @Override
-    public void startEdit() {
+    void startEdit() {
         super.startEdit();
         if (isEmpty()) {
             return;
@@ -79,19 +79,19 @@ class EditingCell extends TableCell implements EventHandler {
     }
 
     @Override
-    public void cancelEdit() {
+    void cancelEdit() {
         super.cancelEdit();
         setContentDisplay(ContentDisplay.TEXT_ONLY);
     }
 
     @Override
-    public void commitEdit(Object t) {
+    void commitEdit(Object t) {
         super.commitEdit(t);
         setContentDisplay(ContentDisplay.TEXT_ONLY);
     }
 
     @Override
-    public void updateItem(Object item, boolean empty) {
+    void updateItem(Object item, boolean empty) {
         super.updateItem(item, empty);
         if (!isEmpty()) {
             if (textField != null) {
@@ -101,8 +101,8 @@ class EditingCell extends TableCell implements EventHandler {
             setContentDisplay(ContentDisplay.TEXT_ONLY);
         }
     }
-    
-    public void handle(Event t) { 
+
+    void handle(Event t) {
         if (t.getCode() == KeyCode.ENTER) {
             commitEdit(textField.getText());
         } else if (t.getCode() == KeyCode.ESCAPE) {
@@ -114,12 +114,12 @@ class EditingCell extends TableCell implements EventHandler {
 
 class EnumEditingCallback implements javafx.util.Callback {
     public Class enumClass;
-    
-    public EnumEditingCallback(Class enumClass) {
+
+    EnumEditingCallback(Class enumClass) {
         this.enumClass = enumClass;
     }
-    
-    public Object call(Object column) {
+
+    Object call(Object column) {
         return new EnumEditingCell(enumClass);
     }
 }
@@ -130,13 +130,13 @@ class EnumEditingCell extends TableCell implements ChangeListener {
     private ChoiceBox choiceBox;
     public Class enumClass;
 
-    public EnumEditingCell(Class enumClass) {
+    EnumEditingCell(Class enumClass) {
         this.setEditable(true);
         this.enumClass = enumClass;
     }
 
     @Override
-    public void startEdit() {
+    void startEdit() {
         super.startEdit();
         if (isEmpty()) {
             return;
@@ -153,19 +153,19 @@ class EnumEditingCell extends TableCell implements ChangeListener {
     }
 
     @Override
-    public void cancelEdit() {
+    void cancelEdit() {
         super.cancelEdit();
         setContentDisplay(ContentDisplay.TEXT_ONLY);
     }
 
     @Override
-    public void commitEdit(Object t) {
+    void commitEdit(Object t) {
         super.commitEdit(t);
         setContentDisplay(ContentDisplay.TEXT_ONLY);
     }
 
     @Override
-    public void updateItem(Object item, boolean empty) {
+    void updateItem(Object item, boolean empty) {
         super.updateItem(item, empty);
         if (!isEmpty()) {
             if (choiceBox != null) {
@@ -191,9 +191,9 @@ class EnumEditingCell extends TableCell implements ChangeListener {
         choiceBox.getSelectionModel().select(getItem());
         choiceBox.getSelectionModel().selectedItemProperty().addListener(this);
 
-    }  
-    
-    public void changed(ObservableValue observable, Object oldValue, Object newValue) {
+    }
+
+    void changed(ObservableValue observable, Object oldValue, Object newValue) {
         commitEdit(newValue); 
     }
 }
@@ -203,13 +203,13 @@ class EnumEditingCell extends TableCell implements ChangeListener {
 class ConverterPropertyValueFactory extends PropertyValueFactory implements ChangeListener {
     public Closure converter;
     private StringProperty destination;
-    
-    public ConverterPropertyValueFactory(String property, Closure converter) {
+
+    ConverterPropertyValueFactory(String property, Closure converter) {
         super(property);
         this.converter = converter; 
     }
-    
-    public ObservableValue call(TableColumn.CellDataFeatures param) {
+
+    ObservableValue call(TableColumn.CellDataFeatures param) {
         ObservableValue origin = super.call(param);
         Object originValue = origin.getValue();
         String result = originValue == null ? "" : converter.call(originValue);
@@ -222,8 +222,8 @@ class ConverterPropertyValueFactory extends PropertyValueFactory implements Chan
         }
         
     }
-    
-    public void changed(ObservableValue observable, Object oldValue, Object newValue) {
+
+    void changed(ObservableValue observable, Object oldValue, Object newValue) {
         String result = "";
         if(newValue != null) 
              result = converter.call(newValue);
@@ -235,12 +235,12 @@ class ConverterPropertyValueFactory extends PropertyValueFactory implements Chan
 class TableFactory extends AbstractNodeFactory {
     private static EditingCallback defaultCellFactory = new EditingCallback();
     private static EnumEditingCallback enumCellFactory = new EnumEditingCallback();
-    
-    public TableFactory(Class beanClass) {
+
+    TableFactory(Class beanClass) {
         super(beanClass)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Object result = super.newInstance(builder, name, value, attributes);
         if(TableColumn.isAssignableFrom(beanClass) && value != null) {
             result.text = value.toString()
@@ -307,13 +307,13 @@ class TableFactory extends AbstractNodeFactory {
         return super.onHandleNodeAttributes(builder, node, attributes);
     }
 
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
         if((parent instanceof TableView || parent instanceof TableColumn) && child instanceof TableColumn) {
             parent.columns.add(child);
         }else if(child instanceof GroovyCallback) {
             if(parent instanceof TableView && child.property == "onSelect") {
                    parent.selectionModel.selectedItemProperty().addListener(new ChangeListener() {
-                        public void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
+                        void changed(final ObservableValue observable, final Object oldValue, final Object newValue) {
                             builder.defer({child.closure.call(parent, oldValue, newValue);});
                         }
                     });      

--- a/src/main/groovy/groovyx/javafx/factory/TableRowFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TableRowFactory.groovy
@@ -26,12 +26,14 @@ import javafx.scene.control.TableRow;
 class TableRowFactory   {
     Closure factory;
 
-    public TableRowFactory() {
+    TableRowFactory() {
     }
-    public TableRowFactory(Closure factory) {
+
+    TableRowFactory(Closure factory) {
         this.factory = factory;
     }
-    public TableRow run() {
+
+    TableRow run() {
         TableRow result = factory.call();
 
         return result;

--- a/src/main/groovy/groovyx/javafx/factory/TextFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TextFactory.groovy
@@ -33,7 +33,7 @@ class TextFactory extends AbstractNodeFactory {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes)
         throws InstantiationException, IllegalAccessException {
         Text text = super.newInstance(builder, name, value, attributes)
         if(value != null)

--- a/src/main/groovy/groovyx/javafx/factory/TitledContent.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TitledContent.groovy
@@ -27,8 +27,8 @@ import javafx.scene.control.TitledPane
 class TitledContent {
     public TitledPane pane;
     public Node node;
-    
-    public void setNode(Node node) {
+
+    void setNode(Node node) {
         this.node = node;
         pane.content = node
     }

--- a/src/main/groovy/groovyx/javafx/factory/TitledFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TitledFactory.groovy
@@ -25,17 +25,17 @@ class TitledFactory extends AbstractFXBeanFactory {
     TitledFactory(Class beanClass) {
         super(beanClass)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         def result = super.newInstance(builder, name, value, attributes);
         result;
     }
 
-    public boolean isHandlesNodeChildren() {
+    boolean isHandlesNodeChildren() {
         return false;
     }
 
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         parent.node = child
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/TitledNode.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TitledNode.groovy
@@ -28,8 +28,8 @@ class TitledNode {
     public TitledPane pane;
     
     public Node node;
-    
-    public void setNode(Node node) {
+
+    void setNode(Node node) {
         this.node = node;
         pane.graphic = node
     }

--- a/src/main/groovy/groovyx/javafx/factory/TransitionFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TransitionFactory.groovy
@@ -40,7 +40,7 @@ import javafx.util.Duration
  */
 class TransitionFactory extends AbstractFXBeanFactory {
     
-    public TransitionFactory(Class<Transition> beanClass) {
+    TransitionFactory(Class<Transition> beanClass) {
         super(beanClass);
     }
     
@@ -61,8 +61,8 @@ class TransitionFactory extends AbstractFXBeanFactory {
         }
         return result;
     }
-    
-    public void setChild(FactoryBuilderSupport build, Object parent, Object child) {
+
+    void setChild(FactoryBuilderSupport build, Object parent, Object child) {
         if((parent instanceof ParallelTransition || parent instanceof SequentialTransition)) {
             if(child instanceof Transition) {
                 parent.children.add(child);

--- a/src/main/groovy/groovyx/javafx/factory/TreeItemFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/TreeItemFactory.groovy
@@ -43,22 +43,23 @@ class TreeItemFactory extends AbstractFXBeanFactory {
         treeItemEvents.onExpandedItemCountChange = TreeItem."$constName"
     }
 
-    public TreeItemFactory() {
+    TreeItemFactory() {
         super(TreeItem)
     }
 
-    public TreeItemFactory(Class<TreeItem> beanClass) {
+    TreeItemFactory(Class<TreeItem> beanClass) {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         TreeItem item = super.newInstance(builder, name, value, attributes)
         if(!checkValue(name, value)) {
             item.value = value
         }
         item;
     }
-    public void setChild( FactoryBuilderSupport builder, Object parent, Object child ) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child ) {
         switch(child) {
             case TreeItem:
                 parent.children.add(child);
@@ -77,8 +78,8 @@ class TreeItemFactory extends AbstractFXBeanFactory {
         }
     }
 
-    public boolean onHandleNodeAttributes( FactoryBuilderSupport builder, Object node,
-            Map attributes ) {
+    boolean onHandleNodeAttributes(FactoryBuilderSupport builder, Object node,
+                                   Map attributes ) {
         for(v in treeItemEvents) {
             if(attributes.containsKey(v)) {
                 def val = attributes.remove(v);

--- a/src/main/groovy/groovyx/javafx/factory/WebFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/WebFactory.groovy
@@ -34,7 +34,8 @@ class WebFactory extends AbstractNodeFactory {
     WebFactory(Class beanClass) {
         super(beanClass)
     }
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Object instance = super.newInstance(builder, name, value, attributes)
 
         if(WebView.isAssignableFrom(beanClass)) {
@@ -50,8 +51,8 @@ class WebFactory extends AbstractNodeFactory {
 
         instance;
     }
-    
-    public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
+
+    void setChild(FactoryBuilderSupport builder, Object parent, Object child) {
         if(parent instanceof WebView) {
             switch(child) {
                 case GroovyEventHandler:
@@ -59,8 +60,8 @@ class WebFactory extends AbstractNodeFactory {
                     if(child.property == "onLoad") {
                         def listener = new ChangeListener<State>() {
                                 @Override
-                                public void changed(ObservableValue<? extends State> observable, 
-                                            State oldState, State newState) {
+                                void changed(ObservableValue<? extends State> observable,
+                                             State oldState, State newState) {
                                     switch(newState) {
                                         case State.SUCCEEDED:
                                             child.closure.call(parent);
@@ -76,8 +77,8 @@ class WebFactory extends AbstractNodeFactory {
                     }else if(child.property == "onError") {
                         def listener = new ChangeListener<State>() {
                                 @Override
-                                public void changed(ObservableValue<? extends State> observable, 
-                                            State oldState, State newState) {
+                                void changed(ObservableValue<? extends State> observable,
+                                             State oldState, State newState) {
                                     switch(newState) {
                                         case State.FAILED:
                                             child.closure.call(parent.engine.loadWorker.message, parent.engine.loadWorker.exception);

--- a/src/main/groovy/groovyx/javafx/factory/XYSeriesFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/XYSeriesFactory.groovy
@@ -34,11 +34,12 @@ import javafx.scene.chart.XYChart
  */
 class XYSeriesFactory extends AbstractFXBeanFactory {
     public static final String SERIES_LIST_PROPERTY = "__seriesList"
-    
-    public XYSeriesFactory() {
+
+    XYSeriesFactory() {
         super(XYChart.Series)
     }
-    public XYSeriesFactory(Class<XYChart.Series> beanClass) {
+
+    XYSeriesFactory(Class<XYChart.Series> beanClass) {
         super(beanClass)
     }
 
@@ -48,7 +49,7 @@ class XYSeriesFactory extends AbstractFXBeanFactory {
      * @param list The list of data points.  Can be either [x1, y1, x2, y2, ...] or [[x1, y1], [x2, y2], ...].
      * @return An ObservableList of XYChart.Data objects.
      */
-    public static ObservableList<XYChart.Data> createXYDataFromList(List list) {
+    static ObservableList<XYChart.Data> createXYDataFromList(List list) {
         def result = []
 
         if (list) {

--- a/src/main/groovy/groovyx/javafx/factory/animation/Binding.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/Binding.groovy
@@ -30,14 +30,14 @@ class Binding {
     public Object bean;
     public String property;
 
-    public void updateValue(Object value) {
+    void updateValue(Object value) {
         try {
             InvokerHelper.setProperty(bean, propertyName, newValue);
         } catch (InvokerInvocationException iie) {
             if (!(iie.getCause() instanceof PropertyVetoException)) {
                 throw iie;
             }
-            // ignore veto exceptions, just let the binding fail like a validaiton does
+            // ignore veto exceptions, just let the binding fail like a validation does
         }
     }
 	

--- a/src/main/groovy/groovyx/javafx/factory/animation/GroovyVariable.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/GroovyVariable.groovy
@@ -45,12 +45,12 @@ class GroovyVariable  implements ChangeListener, WritableValue {
 
     Object variable;
 
-    public void setBean(Object bean) {
+    void setBean(Object bean) {
         this.bean = bean;
         initialize();
     }
 
-    public void setProperty(String property) {
+    void setProperty(String property) {
         this.property = property;
         initialize();
     }
@@ -80,13 +80,13 @@ class GroovyVariable  implements ChangeListener, WritableValue {
         }
 
     }
-    
-    public void changed(ObservableValue observable, Object oldValue, Object newValue) {
+
+    void changed(ObservableValue observable, Object oldValue, Object newValue) {
         setPropertyValue(newValue);
     }
 
 
-    public Object getValue() {
+    Object getValue() {
         Object value = null;
         try {
             value = InvokerHelper.getProperty(bean, property);
@@ -113,7 +113,7 @@ class GroovyVariable  implements ChangeListener, WritableValue {
     /**
      * sets the Variable property to this value, that interns sets the Groovy property to this value
      */
-    public void setValue(Object newValue) {
+    void setValue(Object newValue) {
         variable.setValue(newValue);
     }
 

--- a/src/main/groovy/groovyx/javafx/factory/animation/KeyFrameFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/KeyFrameFactory.groovy
@@ -36,8 +36,8 @@ class KeyFrameFactory extends AbstractFXBeanFactory {
     KeyFrameFactory(Class<KeyFrameWrapper> beanClass) {
         super(beanClass)
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         KeyFrameWrapper keyFrame = super.newInstance(builder, name, value, attributes)
         keyFrame.time = (Duration)value;
 
@@ -51,8 +51,8 @@ class KeyFrameFactory extends AbstractFXBeanFactory {
         }
         keyFrame;
     }
-    
-    public void setChild(FactoryBuilderSupport build, Object parent, Object child) {
+
+    void setChild(FactoryBuilderSupport build, Object parent, Object child) {
         if(child instanceof GroovyEventHandler) {
             FXHelper.setPropertyOrMethod(parent, child.property, child)
         }else {
@@ -60,7 +60,7 @@ class KeyFrameFactory extends AbstractFXBeanFactory {
         }
     }
 
-    public void onNodeCompleted( FactoryBuilderSupport builder, Object parent, Object node )  {
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node )  {
         def keyValues = builder.context[KeyValueFactory.TARGET_HOLDERS_PROPERTY]
         keyValues?.each {
             KeyValue kv = it.getKeyValue();

--- a/src/main/groovy/groovyx/javafx/factory/animation/KeyFrameWrapper.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/KeyFrameWrapper.groovy
@@ -32,7 +32,7 @@ class KeyFrameWrapper {
     public EventHandler<ActionEvent> onFinished = null;
     public Collection<KeyValue> values = new ArrayList<KeyValue>();
 
-    public KeyFrame createKeyFrame() {
+    KeyFrame createKeyFrame() {
         return new KeyFrame(time, (String)null, onFinished, (Collection<KeyValue>)values);
     }
 }

--- a/src/main/groovy/groovyx/javafx/factory/animation/KeyValueFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/KeyValueFactory.groovy
@@ -37,8 +37,8 @@ class KeyValueFactory extends AbstractFXBeanFactory {
     KeyValueFactory(Class<TargetHolder> beanClass) {
         super(beanClass);
     }
-    
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         if(checkValue(name, value)) {
             return value;
         }
@@ -53,7 +53,7 @@ class KeyValueFactory extends AbstractFXBeanFactory {
     
     }
 
-    public void setChild(FactoryBuilderSupport build, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport build, Object parent, Object child) {
         if(parent instanceof TargetHolder) {
             if(child instanceof Interpolator) {
                 ((TargetHolder)parent).interpolator = (Interpolator)child;
@@ -63,7 +63,7 @@ class KeyValueFactory extends AbstractFXBeanFactory {
         }
     }
 
-    public void onNodeCompleted( FactoryBuilderSupport builder, Object parent, Object node )  {
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node )  {
         if(node instanceof TargetHolder) {
             def keyValues = builder.parentContext.get(TARGET_HOLDERS_PROPERTY, [])
             keyValues << node

--- a/src/main/groovy/groovyx/javafx/factory/animation/KeyValueSubFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/KeyValueSubFactory.groovy
@@ -30,7 +30,7 @@ class KeyValueSubFactory  extends AbstractFXBeanFactory  {
         super(beanClass)
     }
 
-     public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         if(Interpolator.isAssignableFrom(beanClass)) {
               return getInterpolator(value);      
         }else {
@@ -38,7 +38,7 @@ class KeyValueSubFactory  extends AbstractFXBeanFactory  {
         }
      }
 
-     public static Interpolator getInterpolator(Object interpolate) {
+    static Interpolator getInterpolator(Object interpolate) {
         if(interpolate == null)
             return Interpolator.LINEAR;
         if(interpolate instanceof Interpolator) {

--- a/src/main/groovy/groovyx/javafx/factory/animation/TimelineFactory.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/TimelineFactory.groovy
@@ -38,7 +38,7 @@ class TimelineFactory extends AbstractFXBeanFactory {
         super(beanClass)
     }
 
-    public Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
+    Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes) throws InstantiationException, IllegalAccessException {
         Timeline timeline 
         frames = new ArrayList<KeyFrameWrapper>();
         def framerate = attributes.remove("framerate");
@@ -59,7 +59,7 @@ class TimelineFactory extends AbstractFXBeanFactory {
         
     }
 
-    public void setChild(FactoryBuilderSupport build, Object parent, Object child) {
+    void setChild(FactoryBuilderSupport build, Object parent, Object child) {
         if(child instanceof KeyFrameWrapper) {
             frames.add(child);
         }else if(child instanceof GroovyEventHandler) {
@@ -70,7 +70,7 @@ class TimelineFactory extends AbstractFXBeanFactory {
     }
 
 
-     public void onNodeCompleted( FactoryBuilderSupport builder, Object parent, Object node )  {
+    void onNodeCompleted(FactoryBuilderSupport builder, Object parent, Object node )  {
         if(node instanceof Timeline) {
             Timeline tl = (Timeline) node;
             for(KeyFrameWrapper w : frames) {

--- a/src/main/groovy/groovyx/javafx/factory/animation/VarRef.groovy
+++ b/src/main/groovy/groovyx/javafx/factory/animation/VarRef.groovy
@@ -24,7 +24,7 @@ package groovyx.javafx.factory.animation
 class VarRef {
     Object varName
 
-    public String toString() {
+    String toString() {
         return "${varName.getClass()}:: ${varName}";
     }
 }


### PR DESCRIPTION
Groovy methods don't need the `public` modifier, as they're public by default. This commit removes the `public` from each method where it is not needed.